### PR TITLE
fix: should not dial bind addr directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# IDEs
+.vscode
+.idea
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/client.go
+++ b/client.go
@@ -1,8 +1,10 @@
 package socks5
 
 import (
+	"encoding/binary"
 	"errors"
 	"net"
+	"strconv"
 	"time"
 )
 
@@ -114,7 +116,15 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 		if err != nil {
 			return nil, err
 		}
-		raddr, err := net.ResolveUDPAddr("udp", rp.Address())
+		var addr string
+		if IsAnyIP(rp.BndAddr) {
+			// indicate using conventional addr
+			p := strconv.Itoa(int(binary.BigEndian.Uint16(rp.BndPort)))
+			addr = net.JoinHostPort(laddr.IP.String(), p)
+		} else {
+			addr = rp.Address()
+		}
+		raddr, err := net.ResolveUDPAddr("udp", addr)
 		if err != nil {
 			return nil, err
 		}

--- a/socks5.go
+++ b/socks5.go
@@ -54,6 +54,13 @@ const (
 	RepAddressNotSupported byte = 0x08
 )
 
+var (
+	// AnyIP is a constant value for any IP in IPv4.
+	AnyIP = []byte{0, 0, 0, 0}
+	// AnyIPv6 is a constant value for any IP in IPv6.
+	AnyIPv6 = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+)
+
 // NegotiationRequest is the negotiation reqeust packet
 type NegotiationRequest struct {
 	Ver      byte

--- a/util.go
+++ b/util.go
@@ -78,6 +78,18 @@ func ParseBytesAddress(b []byte) (a byte, addr []byte, port []byte, err error) {
 	return
 }
 
+// IsAnyIP return if the given ip address is an any ip (0.0.0.0 or [::])
+func IsAnyIP(b []byte) bool {
+	switch len(b) {
+	case net.IPv4len:
+		return bytes.Equal(b, AnyIP)
+	case net.IPv6len:
+		return bytes.Equal(b, AnyIPv6)
+	default:
+		return false
+	}
+}
+
 // ToAddress format raw address to x.x.x.x:xx
 // addr contains domain length
 func ToAddress(a byte, addr []byte, port []byte) string {


### PR DESCRIPTION
When server returns an any ip (0.0.0.0 or [::]), we should use conventional ip to replace the any ip given (0.0.0.0 or [::]). This behaviour adapts to most situations.

See v2fly/v2ray-core#523

---

Problem happens when socks5 proxy works on remote servers and different implementation will given different `bind addr`.

For most situations it is issues of servers. However, clients should behave normally in one case that returned `bind addr` is an ANYIP (0.0.0.0 or [::]), which indicate that we should use a conventional remote address to connect.

RFC does not illustrate the mechanism of bind addr; it is based on experience.

