### PR TITLE
Migrate the net.* structures to net.* interface types to allow different transports/address types

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ go get github.com/txthinking/socks5
 * `type Server struct`
 * `type Handler interface`
     * `TCPHandle(*Server, *net.TCPConn, *Request) error`
-    * `UDPHandle(*Server, *net.UDPAddr, *Datagram) error`
+    * `UDPHandle(*Server, net.Addr, *Datagram) error`
 
 Example:
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -61,7 +61,7 @@ $ go get github.com/txthinking/socks5
 * `type Server struct`
 * `type Handler interface`
     * `TCPHandle(*Server, *net.TCPConn, *Request) error`
-    * `UDPHandle(*Server, *net.UDPAddr, *Datagram) error`
+    * `UDPHandle(*Server, net.Addr, *Datagram) error`
 
 举例:
 

--- a/client.go
+++ b/client.go
@@ -52,7 +52,7 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 				return nil, err
 			}
 		}
-		var la *net.TCPAddr
+		var la net.Addr
 		if src != "" {
 			la, err = net.ResolveTCPAddr("tcp", src)
 			if err != nil {
@@ -81,7 +81,7 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 				return nil, err
 			}
 		}
-		var la *net.TCPAddr
+		var la net.Addr
 		if src != "" {
 			la, err = net.ResolveTCPAddr("tcp", src)
 			if err != nil {
@@ -92,7 +92,7 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 			return nil, err
 		}
 
-		var laddr *net.UDPAddr
+		var laddr net.Addr
 		if src != "" {
 			laddr, err = net.ResolveUDPAddr("udp", src)
 			if err != nil {
@@ -101,9 +101,9 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 		}
 		if src == "" {
 			laddr = &net.UDPAddr{
-				IP:   c.Conn.LocalAddr().(*net.TCPAddr).IP,
-				Port: c.Conn.LocalAddr().(*net.TCPAddr).Port,
-				Zone: c.Conn.LocalAddr().(*net.TCPAddr).Zone,
+				IP:   c.Conn.LocalAddr().(*net.UDPAddr).IP,
+				Port: c.Conn.LocalAddr().(*net.UDPAddr).Port,
+				Zone: c.Conn.LocalAddr().(*net.UDPAddr).Zone,
 			}
 		}
 		a, h, p, err := ParseAddress(laddr.String())
@@ -118,7 +118,7 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 		if err != nil {
 			return nil, err
 		}
-		c.PacketConn, err = Dial.DialUDP("udp", laddr, raddr)
+		c.PacketConn, err = Dial.DialUDP("udp", laddr.(*net.UDPAddr), raddr)
 		if err != nil {
 			return nil, err
 		}
@@ -213,12 +213,12 @@ func (c *Client) SetWriteDeadline(t time.Time) error {
 	return c.PacketConn.SetWriteDeadline(t)
 }
 
-func (c *Client) Negotiate(laddr *net.TCPAddr) error {
+func (c *Client) Negotiate(laddr net.Addr) error {
 	raddr, err := net.ResolveTCPAddr("tcp", c.Server)
 	if err != nil {
 		return err
 	}
-	c.Conn, err = Dial.DialTCP("tcp", laddr, raddr)
+	c.Conn, err = Dial.DialTCP("tcp", laddr.(*net.TCPAddr), raddr)
 	if err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -47,14 +47,14 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 	var err error
 	if network == "tcp" {
 		if c.RemoteAddress == nil {
-			c.RemoteAddress, err = net.ResolveTCPAddr("tcp", dst)
+			c.RemoteAddress, err = Resolver.ResolveTCPAddr("tcp", dst)
 			if err != nil {
 				return nil, err
 			}
 		}
 		var la net.Addr
 		if src != "" {
-			la, err = net.ResolveTCPAddr("tcp", src)
+			la, err = Resolver.ResolveTCPAddr("tcp", src)
 			if err != nil {
 				return nil, err
 			}
@@ -76,14 +76,14 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 	}
 	if network == "udp" {
 		if c.RemoteAddress == nil {
-			c.RemoteAddress, err = net.ResolveUDPAddr("udp", dst)
+			c.RemoteAddress, err = Resolver.ResolveUDPAddr("udp", dst)
 			if err != nil {
 				return nil, err
 			}
 		}
 		var la net.Addr
 		if src != "" {
-			la, err = net.ResolveTCPAddr("tcp", src)
+			la, err = Resolver.ResolveTCPAddr("tcp", src)
 			if err != nil {
 				return nil, err
 			}
@@ -94,7 +94,7 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 
 		var laddr net.Addr
 		if src != "" {
-			laddr, err = net.ResolveUDPAddr("udp", src)
+			laddr, err = Resolver.ResolveUDPAddr("udp", src)
 			if err != nil {
 				return nil, err
 			}
@@ -114,7 +114,7 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 		if err != nil {
 			return nil, err
 		}
-		raddr, err := net.ResolveUDPAddr("udp", rp.Address())
+		raddr, err := Resolver.ResolveUDPAddr("udp", rp.Address())
 		if err != nil {
 			return nil, err
 		}
@@ -214,7 +214,7 @@ func (c *Client) SetWriteDeadline(t time.Time) error {
 }
 
 func (c *Client) Negotiate(laddr net.Addr) error {
-	raddr, err := net.ResolveTCPAddr("tcp", c.Server)
+	raddr, err := Resolver.ResolveTCPAddr("tcp", c.Server)
 	if err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -118,7 +118,7 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 		if err != nil {
 			return nil, err
 		}
-		c.PacketConn, err = Dial.DialUDP("udp", laddr.(*net.UDPAddr), raddr)
+		c.PacketConn, err = Dial.DialUDP("udp", laddr, raddr)
 		if err != nil {
 			return nil, err
 		}
@@ -218,7 +218,7 @@ func (c *Client) Negotiate(laddr net.Addr) error {
 	if err != nil {
 		return err
 	}
-	c.Conn, err = Dial.DialTCP("tcp", laddr.(*net.TCPAddr), raddr)
+	c.Conn, err = Dial.DialTCP("tcp", laddr, raddr)
 	if err != nil {
 		return err
 	}

--- a/connect.go
+++ b/connect.go
@@ -8,7 +8,7 @@ import (
 
 // Connect remote conn which u want to connect with your dialer
 // Error or OK both replied.
-func (r *Request) Connect(w io.Writer) (*net.TCPConn, error) {
+func (r *Request) Connect(w io.Writer) (net.Conn, error) {
 	if Debug {
 		log.Println("Call:", r.Address())
 	}
@@ -25,7 +25,7 @@ func (r *Request) Connect(w io.Writer) (*net.TCPConn, error) {
 		}
 		return nil, err
 	}
-	rc := tmp.(*net.TCPConn)
+	rc := tmp.(net.Conn)
 
 	a, addr, port, err := ParseAddress(rc.LocalAddr().String())
 	if err != nil {

--- a/init.go
+++ b/init.go
@@ -7,6 +7,7 @@ import (
 // Debug enable debug log
 var Debug bool
 var Dial x.Dialer = x.DefaultDial
+var Resolver x.Resolver = x.DefaultResolve
 
 func init() {
 	// log.SetFlags(log.LstdFlags | log.Lshortfile)

--- a/server.go
+++ b/server.go
@@ -55,15 +55,15 @@ func NewClassicServer(addr, ip, username, password string, tcpTimeout, udpTimeou
 	if err != nil {
 		return nil, err
 	}
-	taddr, err := net.ResolveTCPAddr("tcp", addr)
+	taddr, err := Resolver.ResolveTCPAddr("tcp", addr)
 	if err != nil {
 		return nil, err
 	}
-	uaddr, err := net.ResolveUDPAddr("udp", addr)
+	uaddr, err := Resolver.ResolveUDPAddr("udp", addr)
 	if err != nil {
 		return nil, err
 	}
-	saddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(ip, p))
+	saddr, err := Resolver.ResolveUDPAddr("udp", net.JoinHostPort(ip, p))
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +389,7 @@ func (h *DefaultHandle) UDPHandle(s *Server, addr net.Addr, d *Datagram) error {
 	if ok {
 		laddr = any.(net.Addr)
 	}
-	raddr, err := net.ResolveUDPAddr("udp", dst)
+	raddr, err := Resolver.ResolveUDPAddr("udp", dst)
 	if err != nil {
 		return err
 	}

--- a/server.go
+++ b/server.go
@@ -55,15 +55,15 @@ func NewClassicServer(addr, ip, username, password string, tcpTimeout, udpTimeou
 	if err != nil {
 		return nil, err
 	}
-	taddr, err := Resolver.ResolveTCPAddr("tcp", addr)
+	taddr, err := net.ResolveTCPAddr("tcp", addr)
 	if err != nil {
 		return nil, err
 	}
-	uaddr, err := Resolver.ResolveUDPAddr("udp", addr)
+	uaddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
 		return nil, err
 	}
-	saddr, err := Resolver.ResolveUDPAddr("udp", net.JoinHostPort(ip, p))
+	saddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(ip, p))
 	if err != nil {
 		return nil, err
 	}

--- a/udp.go
+++ b/udp.go
@@ -9,7 +9,7 @@ import (
 // UDP remote conn which u want to connect with your dialer.
 // Error or OK both replied.
 // Addr can be used to associate TCP connection with the coming UDP connection.
-func (r *Request) UDP(c *net.TCPConn, serverAddr *net.UDPAddr) (*net.UDPAddr, error) {
+func (r *Request) UDP(c net.Conn, serverAddr *net.UDPAddr) (*net.UDPAddr, error) {
 	var clientAddr *net.UDPAddr
 	var err error
 	if bytes.Compare(r.DstPort, []byte{0x00, 0x00}) == 0 {

--- a/udp.go
+++ b/udp.go
@@ -15,9 +15,9 @@ func (r *Request) UDP(c net.Conn, serverAddr net.Addr) (net.Addr, error) {
 	if bytes.Compare(r.DstPort, []byte{0x00, 0x00}) == 0 {
 		// If the requested Host/Port is all zeros, the relay should simply use the Host/Port that sent the request.
 		// https://stackoverflow.com/questions/62283351/how-to-use-socks-5-proxy-with-tidudpclient-properly
-		clientAddr, err = net.ResolveUDPAddr("udp", c.RemoteAddr().String())
+		clientAddr, err = Resolver.ResolveUDPAddr("udp", c.RemoteAddr().String())
 	} else {
-		clientAddr, err = net.ResolveUDPAddr("udp", r.Address())
+		clientAddr, err = Resolver.ResolveUDPAddr("udp", r.Address())
 	}
 	if err != nil {
 		var p *Reply

--- a/udp.go
+++ b/udp.go
@@ -9,8 +9,8 @@ import (
 // UDP remote conn which u want to connect with your dialer.
 // Error or OK both replied.
 // Addr can be used to associate TCP connection with the coming UDP connection.
-func (r *Request) UDP(c net.Conn, serverAddr *net.UDPAddr) (*net.UDPAddr, error) {
-	var clientAddr *net.UDPAddr
+func (r *Request) UDP(c net.Conn, serverAddr net.Addr) (net.Addr, error) {
+	var clientAddr net.Addr
 	var err error
 	if bytes.Compare(r.DstPort, []byte{0x00, 0x00}) == 0 {
 		// If the requested Host/Port is all zeros, the relay should simply use the Host/Port that sent the request.


### PR DESCRIPTION
Not associated with an existing issue.

Changes proposed in this pull request:
- This PR migrates txthinking/socks5 from using concrete net types(net.TCPAddr, net.TCPConn) to using interface net types(net.Addr, net.Conn, net.PacketConn).
- It also implements the ability to add a custom Resolver and a custom Dialer which use interface types as well.
- This allows developers to use custom dialers and resolves in order to work with alternate pseudo-TLD's directly. In my use case, this pseudo-tld is the `.i2p` space. Developers can now do something like this:

``` Go
package main

import (
	"github.com/eyedeekay/sam3/helper"
	"github.com/eyedeekay/sam3/i2pkeys"
	"github.com/txthinking/socks5"
	"log"
)

func main() {
	// Create a SOCKS5 server
	addr := "127.0.0.1:8888"
	ip := "127.0.0.1"
	username := ""
	password := ""
	tcpTimeout := 60000
	udpTimeout := 60000
	i2pkeys.FakePort = true

	primary, err := sam.I2PPrimarySession("sam-socks", "127.0.0.1:7656", "socks5")
	if err != nil {
		panic(err)
	}

	socks5.Dial = primary
	socks5.Resolver = primary

	server, err := socks5.NewClassicServer(addr, ip, username, password, tcpTimeout, udpTimeout)
	if err != nil {
		panic(err)
	}
	log.Println("Client Created")

	// Create SOCKS5 proxy on localhost port 8000
	if err := server.ListenAndServe(nil); err != nil {
		panic(err)
	}
```

to transparently I2P-ify their applications.