### PR TITLE
Support to use with privoxy

### DIFF
--- a/server_side.go
+++ b/server_side.go
@@ -191,22 +191,24 @@ func NewReply(rep byte, atyp byte, bndaddr []byte, bndport []byte) *Reply {
 
 // WriteTo write reply packet into client
 func (r *Reply) WriteTo(w io.Writer) (int64, error) {
+
+	ret := []byte{r.Ver, r.Rep, r.Rsv, r.Atyp}
+
+	ret = append(ret,
+		r.BndAddr[0],
+		r.BndAddr[1],
+		r.BndAddr[2],
+		r.BndAddr[3],
+		r.BndPort[0],
+		r.BndPort[1])
+
 	var n int
-	i, err := w.Write([]byte{r.Ver, r.Rep, r.Rsv, r.Atyp})
+	i, err := w.Write(ret)
 	n = n + i
 	if err != nil {
 		return int64(n), err
 	}
-	i, err = w.Write(r.BndAddr)
-	n = n + i
-	if err != nil {
-		return int64(n), err
-	}
-	i, err = w.Write(r.BndPort)
-	n = n + i
-	if err != nil {
-		return int64(n), err
-	}
+
 	if Debug {
 		log.Printf("Sent Reply: %#v %#v %#v %#v %#v %#v\n", r.Ver, r.Rep, r.Rsv, r.Atyp, r.BndAddr, r.BndPort)
 	}


### PR DESCRIPTION
修复与三方软件privoxy配合使用
(privoxy是一个HTTP转socks5的软件，可能它有bug导致不支持分散的tcp write，导致此项目的socks5握手流程无法正常完成，改成一次性写入可以解决问题)

Fixes # .

Changes proposed in this pull request:
-
-
-

@mentions
