### PR TITLE
Add Custom Dialer Support

### DIFF
--- a/client.go
+++ b/client.go
@@ -98,7 +98,7 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 		if err != nil {
 			return nil, err
 		}
-		c.UDPConn, err = DialUDP("udp", src, rp.Address())
+		c.UDPConn, err = DialUDP(nil, "udp", src, rp.Address())
 		if err != nil {
 			return nil, err
 		}
@@ -199,7 +199,7 @@ func (c *Client) Negotiate(laddr net.Addr) error {
 		src = laddr.String()
 	}
 	var err error
-	c.TCPConn, err = DialTCP("tcp", src, c.Server)
+	c.TCPConn, err = DialTCP(nil, "tcp", src, c.Server)
 	if err != nil {
 		return err
 	}

--- a/connect.go
+++ b/connect.go
@@ -8,11 +8,11 @@ import (
 
 // Connect remote conn which u want to connect with your dialer
 // Error or OK both replied.
-func (r *Request) Connect(w io.Writer) (net.Conn, error) {
+func (r *Request) Connect(s *Server, w io.Writer) (net.Conn, error) {
 	if Debug {
 		log.Println("Call:", r.Address())
 	}
-	rc, err := DialTCP("tcp", "", r.Address())
+	rc, err := DialTCP(s, "tcp", "", r.Address())
 	if err != nil {
 		var p *Reply
 		if r.Atyp == ATYPIPv4 || r.Atyp == ATYPDomain {

--- a/example_test.go
+++ b/example_test.go
@@ -17,6 +17,11 @@ func ExampleServer() {
 		log.Println(err)
 		return
 	}
+	s.Dial = func(network, addr string) (net.Conn, error) {
+		// custom dialer such wiresocks or ...
+		return net.Dial(network, addr)
+	}
+
 	// You can pass in custom Handler
 	s.ListenAndServe(nil)
 	// #Output:

--- a/init.go
+++ b/init.go
@@ -17,7 +17,10 @@ var Resolve func(network string, addr string) (net.Addr, error) = func(network s
 	return net.ResolveUDPAddr("udp", addr)
 }
 
-var DialTCP func(network string, laddr, raddr string) (net.Conn, error) = func(network string, laddr, raddr string) (net.Conn, error) {
+var DialTCP func(s *Server, network string, laddr, raddr string) (net.Conn, error) = func(s *Server, network string, laddr, raddr string) (net.Conn, error) {
+	if s != nil && s.Dial != nil {
+		return s.Dial(network, raddr)
+	}
 	var la, ra *net.TCPAddr
 	if laddr != "" {
 		var err error
@@ -34,7 +37,11 @@ var DialTCP func(network string, laddr, raddr string) (net.Conn, error) = func(n
 	return net.DialTCP(network, la, ra)
 }
 
-var DialUDP func(network string, laddr, raddr string) (net.Conn, error) = func(network string, laddr, raddr string) (net.Conn, error) {
+var DialUDP func(s *Server, network string, laddr, raddr string) (net.Conn, error) = func(s *Server, network string, laddr, raddr string) (net.Conn, error) {
+	if s != nil && s.Dial != nil {
+		return s.Dial(network, raddr)
+	}
+
 	var la, ra *net.UDPAddr
 	if laddr != "" {
 		var err error


### PR DESCRIPTION
Changes proposed in this pull request:

Add Custom Dialer Support
```go
	s, err := socks5.NewClassicServer("127.0.0.1:1080", "127.0.0.1", "", "", 0, 60)
	if err != nil {
		log.Println(err)
		return
	}
	s.Dial = func(network, addr string) (net.Conn, error) {
		// custom dialer such wiresocks or ...
		return net.Dial(network, addr)
	}

```