### PR TITLE
修复一个bug，在某些情况下client错误使用了ipv4 in ipv6，导致ipv4长度不对

### DIFF
--- a/client.go
+++ b/client.go
@@ -84,7 +84,7 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 			return nil, err
 		}
 
-		a, h, p := ATYPIPv4, net.IPv4zero, []byte{0x00, 0x00}
+		a, h, p := ATYPIPv4, []byte{0x00, 0x00, 0x00, 0x00}, []byte{0x00, 0x00}
 		if src != "" {
 			a, h, p, err = ParseAddress(src)
 			if err != nil {


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
-
-
-

@mentions
