### PR TITLE
Add per-client DialTCP/DialUDP hooks

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,6 +18,16 @@ type Client struct {
 	TCPTimeout    int
 	UDPTimeout    int
 	Dst           string
+
+	// DialTCP and DialUDP, when set, are used instead of the package-level
+	// DialTCP/DialUDP functions to create the connection to the proxy and the
+	// UDP relay socket. This allows per-client control over how the underlying
+	// sockets are created (for example to set SO_MARK or SO_BINDTODEVICE, bind
+	// to a specific interface, or hand in an externally created socket) without
+	// the process-wide effect of overriding the package-level variables. When
+	// nil, the package-level functions are used.
+	DialTCP func(network, laddr, raddr string) (net.Conn, error)
+	DialUDP func(network, laddr, raddr string) (net.Conn, error)
 }
 
 // This is just create a client, you need to use Dial to create conn
@@ -47,6 +57,8 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 		UDPTimeout:    c.UDPTimeout,
 		Dst:           dst,
 		RemoteAddress: remoteAddr,
+		DialTCP:       c.DialTCP,
+		DialUDP:       c.DialUDP,
 	}
 	var err error
 	if network == "tcp" {
@@ -98,7 +110,11 @@ func (c *Client) DialWithLocalAddr(network, src, dst string, remoteAddr net.Addr
 		if err != nil {
 			return nil, err
 		}
-		c.UDPConn, err = DialUDP("udp", src, rp.Address())
+		dialUDP := DialUDP
+		if c.DialUDP != nil {
+			dialUDP = c.DialUDP
+		}
+		c.UDPConn, err = dialUDP("udp", src, rp.Address())
 		if err != nil {
 			return nil, err
 		}
@@ -202,7 +218,11 @@ func (c *Client) Negotiate(laddr net.Addr) error {
 		src = laddr.String()
 	}
 	var err error
-	c.TCPConn, err = DialTCP("tcp", src, c.Server)
+	dialTCP := DialTCP
+	if c.DialTCP != nil {
+		dialTCP = c.DialTCP
+	}
+	c.TCPConn, err = dialTCP("tcp", src, c.Server)
 	if err != nil {
 		return err
 	}

--- a/client_dialer_test.go
+++ b/client_dialer_test.go
@@ -1,0 +1,88 @@
+package socks5
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+// TestClientPerClientDialTCP verifies that a per-client DialTCP is used in
+// preference to the package-level DialTCP, without affecting the global.
+func TestClientPerClientDialTCP(t *testing.T) {
+	sentinel := errors.New("per-client dialTCP called")
+	var gotNetwork, gotRaddr string
+
+	c := &Client{
+		Server: "192.0.2.1:1080",
+		DialTCP: func(network, laddr, raddr string) (net.Conn, error) {
+			gotNetwork, gotRaddr = network, raddr
+			return nil, sentinel
+		},
+	}
+
+	err := c.Negotiate(nil)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected per-client DialTCP to be used, got err=%v", err)
+	}
+	if gotNetwork != "tcp" {
+		t.Errorf("network = %q, want %q", gotNetwork, "tcp")
+	}
+	if gotRaddr != c.Server {
+		t.Errorf("raddr = %q, want %q", gotRaddr, c.Server)
+	}
+}
+
+// TestClientPerClientDialUDP verifies that a per-client DialUDP is used and is
+// preserved through the struct rebuild that DialWithLocalAddr performs.
+func TestClientPerClientDialUDP(t *testing.T) {
+	sentinel := errors.New("per-client dialUDP called")
+
+	// A per-client DialTCP feeds a scripted SOCKS5 negotiation/UDP-associate
+	// reply so that DialWithLocalAddr reaches the DialUDP call.
+	c := &Client{
+		Server: "192.0.2.1:1080",
+		DialTCP: func(network, laddr, raddr string) (net.Conn, error) {
+			return newScriptedProxyConn(), nil
+		},
+		DialUDP: func(network, laddr, raddr string) (net.Conn, error) {
+			return nil, sentinel
+		},
+	}
+
+	_, err := c.DialWithLocalAddr("udp", "", "192.0.2.2:53", nil)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected per-client DialUDP to be used, got err=%v", err)
+	}
+}
+
+// newScriptedProxyConn returns a net.Conn pre-loaded with the proxy-side bytes
+// of a no-auth negotiation reply followed by a successful UDP-associate reply
+// pointing at 192.0.2.3:1234. Writes from the client are discarded.
+func newScriptedProxyConn() net.Conn {
+	reply := []byte{
+		// Negotiation reply: VER=5, METHOD=0 (no auth)
+		Ver, MethodNone,
+		// Request reply: VER=5, REP=0 (success), RSV=0, ATYP=1 (IPv4),
+		// BND.ADDR=192.0.2.3, BND.PORT=1234
+		Ver, RepSuccess, 0x00, ATYPIPv4, 192, 0, 2, 3, 0x04, 0xd2,
+	}
+	return &scriptedConn{r: reply}
+}
+
+type scriptedConn struct {
+	net.Conn
+	r   []byte
+	off int
+}
+
+func (c *scriptedConn) Read(b []byte) (int, error) {
+	if c.off >= len(c.r) {
+		return 0, errors.New("scriptedConn: no more data")
+	}
+	n := copy(b, c.r[c.off:])
+	c.off += n
+	return n, nil
+}
+
+func (c *scriptedConn) Write(b []byte) (int, error) { return len(b), nil }
+func (c *scriptedConn) Close() error                { return nil }


### PR DESCRIPTION
## Summary

Adds two optional function fields to `Client` — `DialTCP` and `DialUDP` — that, when set, are used instead of the package-level `DialTCP`/`DialUDP` variables to create the TCP connection to the proxy and the UDP relay socket.

## Motivation

The package already lets callers customize socket creation by overriding the package-level `DialTCP`/`DialUDP` variables. But those are **process-global**, so they can't express per-client intent — if different `Client` instances need different socket settings, a single override applies to all of them.

A concrete case: binding the proxy/relay sockets per connection with `SO_MARK` / `SO_BINDTODEVICE`, choosing an outbound interface, or handing in an externally created socket — where each client may want a different value. With only the global variable, that's not possible.

These new fields provide the same hook at the `Client` level, so each client controls how its own sockets are created without any process-wide side effect.

## Behavior

- When `DialTCP` / `DialUDP` are nil (the default), the package-level functions are used exactly as before — **fully backward compatible**.
- When set, they take precedence for that client only.
- The fields are preserved through the struct rebuild that `DialWithLocalAddr` performs internally, so they apply to both the TCP and UDP code paths.

## Tests

Adds `client_dialer_test.go`:
- `TestClientPerClientDialTCP` — confirms a per-client `DialTCP` is invoked with the expected network and proxy address.
- `TestClientPerClientDialUDP` — scripts a no-auth negotiation + successful UDP-associate reply so execution reaches the UDP dialer, confirming `DialUDP` is used and survives the internal struct rebuild.

No changes to existing behavior or public function signatures.